### PR TITLE
Feat: Add in-app review prompt

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -85,6 +85,9 @@ kotlin {
 
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.ktor.network.tls.certificates)
+
+            implementation(libs.google.play.review)
+            implementation(libs.google.play.review.ktx)
         }
 
         wasmJsMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/io/middlepoint/tvsleep/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/io/middlepoint/tvsleep/MainActivity.kt
@@ -21,11 +21,14 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import androidx.preference.PreferenceManager
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
+import co.touchlab.kermit.Logger
+import com.google.android.play.core.review.ReviewManagerFactory
 import io.middlepoint.tvsleep.ui.screens.Connecting
 import io.middlepoint.tvsleep.ui.screens.ConnectingScreen
 import io.middlepoint.tvsleep.ui.screens.Debug
@@ -38,82 +41,115 @@ import io.middlepoint.tvsleep.ui.screens.Timer
 import io.middlepoint.tvsleep.ui.screens.timer.TimerScreen
 import io.middlepoint.tvsleep.ui.screens.mapToScreen
 import io.middlepoint.tvsleep.ui.theme.TVsleepTheme
+import androidx.core.content.edit
 
 @Suppress("ktlint:standard:no-consecutive-comments")
 class MainActivity : ComponentActivity() {
-    @OptIn(ExperimentalTvMaterial3Api::class)
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+  @OptIn(ExperimentalTvMaterial3Api::class)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
 
-        setContent {
-            val viewModel by viewModels<MainActivityViewModel>()
-            val homeState by viewModel.homeState.collectAsState()
-            val navController = rememberNavController()
-            val isDebug = remember { BuildConfig.DEBUG }
+    setContent {
+      val viewModel by viewModels<MainActivityViewModel>()
+      val homeState by viewModel.homeState.collectAsState()
+      val navController = rememberNavController()
+      val isDebug = remember { BuildConfig.DEBUG }
 
-            TVsleepTheme {
-                Surface(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .safeContentPadding(),
-                    colors =
-                        SurfaceDefaults.colors(
-                            containerColor = MaterialTheme.colorScheme.background,
-                        ),
-                ) {
-                    NavHost(
-                        navController = navController,
-                        startDestination = Connecting,
-                        enterTransition = { fadeIn(spring(stiffness = Spring.StiffnessMedium)) },
-                        exitTransition = { fadeOut(spring(stiffness = Spring.StiffnessMedium)) },
-                    ) {
-                        composable<Connecting> {
-                            ConnectingScreen {
-                                viewModel.startADBServer()
-                            }
-                        }
-
-                        composable<TimeSelection> {
-                            HomeScreen()
-                        }
-                        composable<Timer> {
-                            TimerScreen()
-                        }
-                        composable<SetupADB> {
-                            SetupScreen()
-                        }
-
-                        composable<Debug> {
-                            DebugScreen(navController, viewModel)
-                        }
-                    }
-
-                    if (isDebug) {
-                        val status by viewModel.outputText.collectAsState("Waiting Status")
-                        Text(
-                            status,
-                            modifier = Modifier.align(Alignment.TopStart),
-                        )
-                    }
-
-                    BackHandler {
-                        finish()
-                    }
-
-                    LaunchedEffect(homeState) {
-                        homeState.let { state ->
-                            navController.navigate(
-                                route = state.mapToScreen(),
-                                navOptions =
-                                    navOptions {
-                                        popUpTo(Connecting) { inclusive = true }
-                                    },
-                            )
-                        }
-                    }
-                }
+      TVsleepTheme {
+        Surface(
+          modifier =
+            Modifier
+              .fillMaxSize()
+              .safeContentPadding(),
+          colors =
+            SurfaceDefaults.colors(
+              containerColor = MaterialTheme.colorScheme.background,
+            ),
+        ) {
+          NavHost(
+            navController = navController,
+            startDestination = Connecting,
+            enterTransition = { fadeIn(spring(stiffness = Spring.StiffnessMedium)) },
+            exitTransition = { fadeOut(spring(stiffness = Spring.StiffnessMedium)) },
+          ) {
+            composable<Connecting> {
+              ConnectingScreen {
+                viewModel.startADBServer()
+              }
             }
+
+            composable<TimeSelection> {
+              HomeScreen()
+              LaunchedEffect(Unit) {
+                showReviewIfNeeded()
+              }
+            }
+            composable<Timer> {
+              TimerScreen()
+            }
+            composable<SetupADB> {
+              SetupScreen()
+            }
+
+            composable<Debug> {
+              DebugScreen(navController, viewModel)
+            }
+          }
+
+          if (isDebug) {
+            val status by viewModel.outputText.collectAsState("Waiting Status")
+            Text(
+              status,
+              modifier = Modifier.align(Alignment.TopStart),
+            )
+          }
+
+          BackHandler {
+            finish()
+          }
+
+          LaunchedEffect(homeState) {
+            homeState.let { state ->
+              navController.navigate(
+                route = state.mapToScreen(),
+                navOptions =
+                  navOptions {
+                    popUpTo(Connecting) { inclusive = true }
+                  },
+              )
+            }
+          }
         }
+      }
     }
+  }
+
+  private fun showReviewIfNeeded() {
+    val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+    val showReviewKey = getString(R.string.key_show_review)
+    val reviewShownKey = getString(R.string.key_review_shown_count)
+    val shouldShowReview = prefs.getBoolean(showReviewKey, false)
+    val reviewShownCount = prefs.getInt(reviewShownKey, 0)
+    val logger = Logger.withTag("MainActivity")
+
+    if (shouldShowReview && reviewShownCount < 1) {
+      val reviewManager = ReviewManagerFactory.create(this)
+      val request = reviewManager.requestReviewFlow()
+      request.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+          val reviewInfo = task.result
+          reviewManager.launchReviewFlow(this, reviewInfo)
+          prefs.edit(commit = true) {
+            putBoolean(showReviewKey, false)
+            putInt(reviewShownKey, reviewShownCount + 1)
+          }
+          logger.d("Review flow launched, show_review set to false.")
+        } else {
+          logger.e(task.exception) { "Error requesting review flow" }
+        }
+      }
+    } else {
+      logger.d("Not showing review.")
+    }
+  }
 }

--- a/composeApp/src/androidMain/kotlin/io/middlepoint/tvsleep/services/SleepService.kt
+++ b/composeApp/src/androidMain/kotlin/io/middlepoint/tvsleep/services/SleepService.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationCompat
+import androidx.preference.PreferenceManager
 import androidx.tv.material3.MaterialTheme
 import co.touchlab.kermit.Logger
 import io.middlepoint.tvsleep.R
@@ -196,6 +197,9 @@ class SleepService : Service() {
         if (state is TimerState.Finished) {
           logger.d("Timer finished. Putting device to sleep.")
           try {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+            prefs.edit().putBoolean("show_review", true).apply()
+            logger.d("Set show_review preference to true.")
             adb.goToSleep()
           } catch (e: Exception) {
             logger.e(e) { "Error putting device to sleep" }

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -13,9 +13,11 @@
     <string name="timer_setup_title">Set Watch Time</string>
     <string name="app_selection_title">Select an App</string>
     <string name="checking_device_setup">Checking Device Setup</string>
+    <string name="start_timer_only">Start Timer Only</string>
 
     <string name="auto_shell_key">auto_shell</string>
     <string name="startup_command_key">startup_command</string>
     <string name="buffer_size_key">buffer_size</string>
-    <string name="start_timer_only">Start Timer Only</string>
+    <string name="key_show_review">show_review</string>
+    <string name="key_review_shown_count">review_shown_count</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,15 +3,15 @@ agp = "8.13.0"
 kotlin = "2.2.20"
 coreKtx = "1.17.0"
 appcompat = "1.7.1"
-compose = "1.9.0"
+compose = "1.9.1"
 ktlintVersion = "0.4.27"
 tvFoundation = "1.0.0-alpha12"
 tvMaterial = "1.0.1"
 materialIcons = "1.7.8"
 androidx-lifecycle = "2.9.4"
 activityCompose = "1.11.0"
-androidx-navigation-compose= "2.9.0"
-ktor = "3.3.0"
+androidx-navigation-compose= "2.9.1"
+ktor = "3.3.1"
 kermit = "2.0.8"
 ktlint = "13.1.0"
 preferenceKtx = "1.2.1"
@@ -21,7 +21,9 @@ smoothMotion= "1.0.1"
 constraintlayout-compose-multiplatform= "0.6.1"
 nodeJs= "7.1.0"
 kotlinx-serialization = "1.9.0"
-coil = "2.6.0"
+coil = "2.7.0"
+review = "2.0.2"
+review-ktx = "2.0.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -67,6 +69,8 @@ androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-p
 
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+google-play-review = { group = "com.google.android.play", name = "review", version.ref = "review" }
+google-play-review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "review-ktx" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
This commit introduces an in-app review prompt that appears after the timer successfully puts the device to sleep.

Key changes:
- Added Google Play In-App Review dependencies (`play.review` and `play.review.ktx`).
- The `SleepService` now sets a `show_review` preference to `true` when the timer finishes.
- In `MainActivity`, a `showReviewIfNeeded()` function is called from the `HomeScreen` to launch the review flow if the preference is set.
- The review prompt is designed to show only once.
- Added new string resources for preference keys (`key_show_review`, `key_review_shown_count`).
- Updated various dependencies, including Compose, Navigation, Ktor, and Coil.